### PR TITLE
fix(templates): fix SpotFleet service role

### DIFF
--- a/templates/render-farm.template
+++ b/templates/render-farm.template
@@ -199,7 +199,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
 
   rRenderFarmLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
Previously created AmazonEC2SpotFleetRole role has been deprecated, see https://docs.aws.amazon.com/batch/latest/userguide/troubleshooting.html?shortFooter=true#spot-instance-no-tag

*Issue #, if available:*
N/A
*Description of changes:*
+ fix SpotFleet service role

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
